### PR TITLE
Stop requiring to slashes after `webapp:` in the custom URI format

### DIFF
--- a/src/eos-browser-appmode
+++ b/src/eos-browser-appmode
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 #
-# eos-browser-appmode: takes an URI like webapp://<WM_CLASS>@<ACTUAL_URI>,
+# eos-browser-appmode: takes an URI like webapp:<WM_CLASS>@<ACTUAL_URI>,
 # parses it and and launches chromium-browser with --class and --app arguments.
 #
 # Copyright (C) 2016, 2017 Endless Mobile, Inc.
@@ -50,12 +50,12 @@ class ParsingError(Exception):
 
 
 def parseURI(uri):
-   if not str.startswith(uri, 'webapp://'):
+   if not str.startswith(uri, 'webapp:'):
       raise ParsingError('Wrong URI scheme')
 
    # Get the application ID, to be used to set WM_CLASS,
    # and the URI we want to launch in application mode.
-   uri_parts = uri[9:].split('@', 2)
+   uri_parts = uri[7:].split('@', 2)
    if len(uri_parts) < 2:
       raise ParsingError('Invalid URI format')
 
@@ -104,7 +104,7 @@ if __name__ == '__main__':
                         '--user-data-dir={}'.format(config_dir)])
    except ParsingError as e:
       print('Error parsing custom URI: {}'.format(e.value))
-      print('Usage: eos-browser-appmode webapp://<WM_CLASS>@<URI>')
+      print('Usage: eos-browser-appmode webapp:<WM_CLASS>@<URI>')
       sys.exit(2)
    except OSError as e:
       print('Error launching chromium: {}'.format(e.value))


### PR DESCRIPTION
Newer (and more accurate) implementations are rightfully so parsing
URIs constructed that way as if they had an 'user info' section
matching the WM_CLASS, a host matching the scheme of the actual URI
and a default connection port `0`, which breaks this whole thing.

To prevent that problem from happening, we can use the alternative
syntax without a `//` after the scheme, which basically makes parsers
to consider everything after `webapp:` as a very long path, that will
get handled "as is" by eos-browsers-appmode, without getting certain
GVfs backends adapting the URI into something else that wouldn't work.

See https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#Syntax

https://phabricator.endlessm.com/T19741