### PR TITLE
Exit earlier right after launching Chrome (don't wait for it)

### DIFF
--- a/chrome-helper/eos-google-chrome.py
+++ b/chrome-helper/eos-google-chrome.py
@@ -65,9 +65,6 @@ class GoogleChromeLauncher:
             except OSError as e:
                 exit_with_error("Could not launch Google Chrome: {}".format(repr(e)))
 
-            launcher_process.wait()
-            logging.info("Google Chrome launcher stopped")
-
     def _install_chrome(self):
         try:
             subprocess.Popen([os.path.join(config.PKG_DATADIR, 'eos-google-chrome-installer.py')])


### PR DESCRIPTION
In the past, we did wait for Chrome to finish because this launcher script
was also responsible for keeping the flatpak sandbox artificially alive in
order to protect the app's deployment from being modified (e.g. updated)
while running.

However, that responsibility has been moved to the Chrome's flatpak itself,
which has now a launcher script that takes care of keeping the sandbox alive,
rendering this extra monitoring here unnecessary and wasteful.

Since Popen creates a new child process that can be run independently of this
launcher script, stop waiting for Chrome to finish and exit after launching it.

https://phabricator.endlessm.com/T20459