### PR TITLE
eos-browser-appmode: disable extensions

### DIFF
--- a/src/eos-browser-appmode
+++ b/src/eos-browser-appmode
@@ -101,6 +101,7 @@ if __name__ == '__main__':
                         '--start-maximized',
                         '--no-default-browser-check',
                         '--no-first-run',
+                        '--disable-extensions',
                         '--user-data-dir={}'.format(config_dir)])
    except ParsingError as e:
       print('Error parsing custom URI: {}'.format(e.value))


### PR DESCRIPTION
Now that we have the Adblock Plus extension installed by default,
it will show a banner the first time the browser is launched.
Since each webapp saves its own environment, this pops up
a banner window in front of the actual webapp window the first
time each webapp is launched.

To avoid user annoyance/confusion, let's simply disable extensions
when launching webapps.  This is probably a good policy anyhow,
since we don't need the adblocker for the webapps we have curated,
and the UI of the webapps does not provide any indication of the
extensions in use or access to their customization.

https://phabricator.endlessm.com/T22618