### PR TITLE
chrome-helper: Fix Google Chrome unique ID

### DIFF
--- a/chrome-helper/eos-google-chrome-installer.py
+++ b/chrome-helper/eos-google-chrome-installer.py
@@ -219,9 +219,9 @@ class GoogleChromeInstaller:
         # Get the default branch now to construct the full unique ID GNOME Software expects.
         default_branch = remote.get_default_branch()
         if default_branch:
-            chrome_app_center_id = 'system/flatpak/{}/desktop/{}.desktop/{}'.format(config.FLATPAK_REMOTE_EOS_APPS,
-                                                                                    config.FLATPAK_CHROME_APP_ID,
-                                                                                    default_branch)
+            chrome_app_center_id = 'system/flatpak/{}/desktop/{}/{}'.format(config.FLATPAK_REMOTE_EOS_APPS,
+                                                                            config.FLATPAK_CHROME_APP_ID,
+                                                                            default_branch)
         return chrome_app_center_id
 
     def _run_app_center_for_chrome(self):


### PR DESCRIPTION
Remove `.desktop` suffix which is appending to the google chrome's
base app id. This is done because there was a mis-match
between gnome-software flatpak plugin's created GsApp with source-id
as : system/flatpak/eos-apps/desktop/com.google.Chrome/eos3

versus

A wildcard app being created in gnome-software with unique-id from
chrome-helper as:
system/flatpak/eos-apps/desktop/com.google.Chrome.desktop/eos3

The mismatch resulted in a broken page for Google Chrome installation
in OS images built with gnome-software 3.32.

The mismatch occured because of a change in gnome-software-3-32,
where the flatpak plugin strips the `.desktop` suffix from the
appstream. See gs_flatpak_fix_id_desktop_suffix_cb in gnome-software
flatpak's plugin.

Needless to say, this change should be accompained with
versions >= 3.32 for gnome-software, hence should be cherry-picked
to stable branches accordingly.

https://phabricator.endlessm.com/T27508