### PR TITLE
data: Add X-Flatpak to google-chrome.desktop to bind to its app ID

### DIFF
--- a/data/google-chrome.desktop
+++ b/data/google-chrome.desktop
@@ -114,6 +114,7 @@ MimeType=text/html;text/xml;application/xhtml_xml;image/webp;x-scheme-handler/ht
 X-Ayatana-Desktop-Shortcuts=NewWindow;NewIncognito
 X-Endless-LaunchMaximized=true
 X-Parental-Controls=wrapper
+X-Flatpak=com.google.Chrome
 
 [NewWindow Shortcut Group]
 Name=New Window


### PR DESCRIPTION
In particular, this allows xdg-desktop-portal to associate Chrome
windows with flatpak process instances, so that it knows to not raise a
background application warning about them.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T29677