### PR TITLE
eos-browser-appmode: Turn it into a simple wrapper to launch a given uri in the default browser

### DIFF
--- a/src/eos-browser-appmode
+++ b/src/eos-browser-appmode
@@ -1,11 +1,11 @@
 #!/usr/bin/python3
 #
 # eos-browser-appmode: takes an URI like webapp:<WM_CLASS>@<ACTUAL_URI>,
-# parses it and and launches chromium-browser with --class and --app arguments.
+# parses it and and launches the default browser with the actual uri.
+# This script is deprecated and kept for backwards-compatibility purposes,
+# new code should use "gio open <ACTUAL_URI>" directly instead.
 #
-# Copyright (C) 2016, 2017 Endless Mobile, Inc.
-# Authors:
-#  Mario Sanchez Prada <mario@endlessm.com>
+# Copyright (C) 2016-2020 Endless OS Foundation LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,22 +22,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import os
-import subprocess
 import sys
-
-import gi
-gi.require_version('Flatpak', '1.0')
-from gi.repository import Flatpak
-from gi.repository import GLib, Gio
-
-
-CHROMIUM_COMMAND = 'chromium-browser'
-CHROMIUM_DATA_DIR = 'chromium-appmode'
-
-CHROME_COMMAND = 'eos-google-chrome'
-CHROME_DATA_DIR = 'chrome-appmode'
-
-FLATPAK_CHROME_APP_ID = 'com.google.Chrome'
 
 
 class ParsingError(Exception):
@@ -72,43 +57,10 @@ if __name__ == '__main__':
    custom_uri = sys.argv[1]
    try:
       (wm_class, actual_uri) = parseURI(custom_uri)
-
-      scheme = GLib.uri_parse_scheme(actual_uri)
-      default_browser = Gio.AppInfo.get_default_for_uri_scheme(scheme)
-      print("Found default browser: {}".format(default_browser.get_display_name()))
-
-      # We only use Chrome if it's the default application AND it's installed, otherwise
-      # we use Chromium and ignore any other browser that might have been set (e.g. Firefox).
-      command = CHROMIUM_COMMAND
-      if CHROME_COMMAND in default_browser.get_executable():
-         installation = Flatpak.Installation.new_system()
-         try:
-            installation.get_current_installed_app(FLATPAK_CHROME_APP_ID, None)
-            print("Chrome set as the default application and available. Selecting...")
-            command = CHROME_COMMAND
-         except GLib.Error as e:
-            print("Chrome set as the default application but not available. Ignoring...")
-
-      # External web apps (i.e. URLs not managed by chromium-browser as extensions) need
-      # to run in an isolated environment not to conflict with the main browsing session.
-      data_dir = CHROME_DATA_DIR if command == CHROME_COMMAND else CHROMIUM_DATA_DIR
-      config_dir = os.path.expanduser('~/.config/{}/{}'.format(data_dir, wm_class))
-      print("Using {} to launch web application (config dir: {})...".format(command, config_dir))
-
-      subprocess.Popen([command,
-                        '--class={}'.format(wm_class),
-                        '--app={}'.format(actual_uri),
-                        '--start-maximized',
-                        '--no-default-browser-check',
-                        '--no-first-run',
-                        '--disable-extensions',
-                        '--user-data-dir={}'.format(config_dir)])
    except ParsingError as e:
       print('Error parsing custom URI: {}'.format(e.value))
       print('Usage: eos-browser-appmode webapp:<WM_CLASS>@<URI>')
-      sys.exit(2)
-   except OSError as e:
-      print('Error launching chromium: {}'.format(e.value))
-      sys.exit(2)
+      exit(2)
 
-   sys.exit(0)
+   # The first "gio" is the command to execute. The second is its argv[0].
+   os.execlp("gio", "gio", "open", actual_uri)


### PR DESCRIPTION
This script is deprecated and kept for backwards-compatibility purposes, new code should use "gio open <ACTUAL_URI>" directly instead.

https://phabricator.endlessm.com/T31136