### PR TITLE
Change malcontent-tools dependency to malcontent

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -35,7 +35,7 @@ Depends: ${misc:Depends},
 	flatpak,
 	gir1.2-flatpak-1.0,
 	gir1.2-glib-2.0,
-	malcontent-tools (>= 0.4.0+dev43.13a1e20-5),
+	malcontent,
 	python3,
 	python3-gi,
 	python3-systemd


### PR DESCRIPTION
We're adopting debian's malcontent packaging, and that has the
`malcontent-client` tool in the `malcontent` package. Since that package
never existed before 0.6.0, we can drop the versioned dependency.

https://phabricator.endlessm.com/T30746