### PR TITLE
Don't claim to support ftp://

### DIFF
--- a/data/google-chrome.desktop
+++ b/data/google-chrome.desktop
@@ -112,7 +112,6 @@ Type=Application
 Categories=Network;WebBrowser;
 MimeType=text/html;text/xml;application/xhtml_xml;image/webp;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/ftp;
 X-Ayatana-Desktop-Shortcuts=NewWindow;NewIncognito
-X-Endless-LaunchMaximized=true
 X-Parental-Controls=wrapper
 X-Flatpak=com.google.Chrome
 
@@ -170,7 +169,6 @@ Name[zh_CN]=新建窗口
 Name[zh_TW]=開新視窗
 Exec=/usr/bin/eos-google-chrome
 TargetEnvironment=Unity
-X-Endless-LaunchMaximized=true
 
 [NewIncognito Shortcut Group]
 Name=New Incognito Window
@@ -224,4 +222,3 @@ Name[zh_CN]=新建隐身窗口
 Name[zh_TW]=新增無痕式視窗
 Exec=/usr/bin/eos-google-chrome --incognito
 TargetEnvironment=Unity
-X-Endless-LaunchMaximized=true

--- a/data/google-chrome.desktop
+++ b/data/google-chrome.desktop
@@ -110,12 +110,12 @@ Terminal=false
 Icon=eos-google-chrome
 Type=Application
 Categories=Network;WebBrowser;
-MimeType=text/html;text/xml;application/xhtml_xml;image/webp;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/ftp;
-X-Ayatana-Desktop-Shortcuts=NewWindow;NewIncognito
+MimeType=application/pdf;application/rdf+xml;application/rss+xml;application/xhtml+xml;application/xhtml_xml;application/xml;image/gif;image/jpeg;image/png;image/webp;text/html;text/xml;x-scheme-handler/http;x-scheme-handler/https;
+Actions=new-window;new-private-window;
 X-Parental-Controls=wrapper
 X-Flatpak=com.google.Chrome
 
-[NewWindow Shortcut Group]
+[Desktop Action new-window]
 Name=New Window
 Name[am]=አዲስ መስኮት
 Name[ar]=نافذة جديدة
@@ -168,9 +168,8 @@ Name[vi]=Cửa sổ Mới
 Name[zh_CN]=新建窗口
 Name[zh_TW]=開新視窗
 Exec=/usr/bin/eos-google-chrome
-TargetEnvironment=Unity
 
-[NewIncognito Shortcut Group]
+[Desktop Action new-private-window]
 Name=New Incognito Window
 Name[ar]=نافذة جديدة للتصفح المتخفي
 Name[bg]=Нов прозорец „инкогнито“
@@ -221,4 +220,3 @@ Name[vi]=Cửa sổ ẩn danh mới
 Name[zh_CN]=新建隐身窗口
 Name[zh_TW]=新增無痕式視窗
 Exec=/usr/bin/eos-google-chrome --incognito
-TargetEnvironment=Unity


### PR DESCRIPTION
I compared the .desktop file Google's Chrome package ships to the one in this repo, and applied the applicable changes.

This should make it possible to choose New Window and New Private Window by right-clicking the Chrome desktop icon. It also adds a number of MIME type handlers, and (in particular) removes the claim to handle the ftp:// URI scheme, which was removed from Chrome 91+, which was my original goal.

https://phabricator.endlessm.com/T32562