### PR TITLE
debian: Fix path to tmpfiles.d snippet

### DIFF
--- a/debian/eos-google-chrome-helper.install
+++ b/debian/eos-google-chrome-helper.install
@@ -1,5 +1,5 @@
-/lib/tmpfiles.d/eos-google-chrome.conf
 /usr/bin/eos-google-chrome
+/usr/lib/tmpfiles.d/eos-google-chrome.conf
 /usr/share/appdata
 /usr/share/applications/google-chrome.desktop
 /usr/share/eos-google-chrome-helper


### PR DESCRIPTION
:facepalm: :facepalm: :facepalm: 

OBS uses `/usr` as a prefix, whereas the default is for it to be empty,
which confused me.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://phabricator.endlessm.com/T32410