### PR TITLE
README: Update for simplification in EOS 4 onwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,34 +14,27 @@ which is currently deprecated but kept for compability purposes.
 
 ## eos-google-chrome-helper
 
-This package provides a system level wrapper application to allow easily
-downloading, installing and running Google Chrome on Endless OS.
-
-This wrapper application does mainly two things when you click on the desktop icon:
-
-  * Integrates with the App Center (GNOME Software) so that it gets open on the page
-    for Google Chrome when you click on the desktop icon and hasn't been installed yet.
-
-  * If Google Chrome has been previously installed (using flatpak as a delivery mechanism),
-    the wrapper script launches chromium with its own sandbox (outside of flatpak), by
-    calling a launcher script that is shipped along with the "headless" flatpak app.
+This package provides a system level wrapper script and `.desktop` file to run Google Chrome on Endless OS. If Google Chrome has been installed from Endless's Flatpak repository (using Flatpak only as the delivery mechanism), the `.desktop` file is made visible (via `TryExec=`), and the wrapper script launches Chrome with its own sandbox (*outside of Flatpak*), by calling a launcher script that is shipped along with the "headless" flatpak app.
 
 This package provides the following elements:
-  * `eos-google-chrome`: wrapper to either launch Chrome or the App Center.
-  * `eos-google-chrome.png`: icon to integrate with the desktop.
+
+  * `eos-google-chrome`: wrapper to launch Chrome, if installed
+  * `eos-google-chrome.png`: icon to integrate with the desktop
   * `google-chrome.desktop`: application information according to the Desktop Entry
   Specification, to integrate with the shell. Note that we can't name it like the
-  icon (i.e. eos-google-chrome.desktop) since that way Google Chrome would not be
+  icon (i.e. `eos-google-chrome.desktop`) since that way Google Chrome would not be
   able to recognize itself when running as the default browser, which would end up
-  with Chromium asking to set itself as the default each time it was run.
+  with Chrome asking to set itself as the default each time it was run.
 
-All this files will be installed, exceptionally, as part of the OSTree, so that the
-icon and the wrapper app are available on the desktop at any time, either to run
-the browser or to install it if not yet available.
+These files are installed as part of the OSTree.
+
+Nowadays it is possible to run Chrome within a Flatpak sandbox, and versions of Chrome are published on Flathub that are installed and run in the normal way. However, Endless OS users have not yet been migrated to use this version.
+
+A previous version of the wrapper made the icon always visible, with the script opening the App Center if Chrome was not installed, and would automatically install Chrome in the background on first login. This mechanism was removed in Endless OS 4.
 
 ## License
 
-eos-browser-tools is Copyright (C) 2016, 2017 Endless Mobile, Inc.
+eos-browser-tools is Copyright Endless OS Foundation LLC
 and is licensed under the terms of the GNU General Public License
 as published by the Free Software Foundation; either version 2 of
 the License, or (at your option) any later version.


### PR DESCRIPTION
https://github.com/endlessm/eos-browser-tools/pull/19 removed most of the mechanism described here, leaving only the "launch Chrome" part of the wrapper script. Update the README accordingly.

https://phabricator.endlessm.com/T32410