### PR TITLE
chrome-helper: Make Chrome use Auto Ozone backend if it is uninformed

### DIFF
--- a/chrome-helper/eos-google-chrome.py
+++ b/chrome-helper/eos-google-chrome.py
@@ -107,6 +107,7 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--debug', dest='debug', action='store_true')
+    parser.add_argument('--enable-features', dest='enable_features', default='WebRTCPipeWireCapturer')
     parser.add_argument('--ozone-platform', dest='ozone_platform')
     parser.add_argument('--ozone-platform-hint', dest='ozone_platform_hint', default='auto')
 
@@ -114,6 +115,13 @@ if __name__ == '__main__':
 
     if parsed_args.debug:
         logging.root.setLevel(logging.DEBUG)
+
+    if parsed_args.enable_features:
+        features = parsed_args.enable_features.split(',')
+        if 'WebRTCPipeWireCapturer' not in features:
+            features.append('WebRTCPipeWireCapturer')
+        features = ','.join(features)
+        otherargs.append(f'--enable-features={features}')
 
     if parsed_args.ozone_platform:
         otherargs.append(f'--ozone-platform={parsed_args.ozone_platform}')

--- a/chrome-helper/eos-google-chrome.py
+++ b/chrome-helper/eos-google-chrome.py
@@ -107,11 +107,18 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--debug', dest='debug', action='store_true')
+    parser.add_argument('--ozone-platform', dest='ozone_platform')
+    parser.add_argument('--ozone-platform-hint', dest='ozone_platform_hint', default='auto')
 
     parsed_args, otherargs = parser.parse_known_args()
 
     if parsed_args.debug:
         logging.root.setLevel(logging.DEBUG)
+
+    if parsed_args.ozone_platform:
+        otherargs.append(f'--ozone-platform={parsed_args.ozone_platform}')
+    elif parsed_args.ozone_platform_hint:
+        otherargs.append(f'--ozone-platform-hint={parsed_args.ozone_platform_hint}')
 
     # Google Chrome is only available for Intel 64-bit
     app_arch = Flatpak.get_default_arch()


### PR DESCRIPTION
Google Chrome will use X11 as the Ozone backend by default, if the backend is uninformed. However, Endless OS 5+ uses Wayland as the XDG session type by default. Then, when users try to open the downloaded LibreOffice files from Chrome, the LibreOffice will be asked using X11 as the session. And, it shows "X11 error: Can't open display".

This patch makes Google Chrome use Auto Ozone backend, if it is uninformed. That leads Chrome use the same session type as XDG session.

https://phabricator.endlessm.com/T34400