### PR TITLE
Revert "chrome-helper: Make Chrome use Auto Ozone backend if it is uninformed"

### DIFF
--- a/chrome-helper/eos-google-chrome.py
+++ b/chrome-helper/eos-google-chrome.py
@@ -108,8 +108,6 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--debug', dest='debug', action='store_true')
     parser.add_argument('--enable-features', dest='enable_features', default='WebRTCPipeWireCapturer')
-    parser.add_argument('--ozone-platform', dest='ozone_platform')
-    parser.add_argument('--ozone-platform-hint', dest='ozone_platform_hint', default='auto')
 
     parsed_args, otherargs = parser.parse_known_args()
 
@@ -122,11 +120,6 @@ if __name__ == '__main__':
             features.append('WebRTCPipeWireCapturer')
         features = ','.join(features)
         otherargs.append(f'--enable-features={features}')
-
-    if parsed_args.ozone_platform:
-        otherargs.append(f'--ozone-platform={parsed_args.ozone_platform}')
-    elif parsed_args.ozone_platform_hint:
-        otherargs.append(f'--ozone-platform-hint={parsed_args.ozone_platform_hint}')
 
     # Google Chrome is only available for Intel 64-bit
     app_arch = Flatpak.get_default_arch()


### PR DESCRIPTION
This reverts commit 4ed28caa39cdf4c2867d0c378c88fb38fb25f0e5.

The root cause of original problem: "Can't open LibreOffice documents from eos-apps Chrome" (T34400) is identified in the flatpak's pull request "flatpak-run: Unset GDK_BACKEND" [1]. And, it is merged by upstream and picked into Endless OS' flatpak [2]. So, the workaround commit ("chrome-helper: Make Chrome use Auto Ozone backend if it is uninformed") can be reverted safely.

[1]: https://github.com/flatpak/flatpak/pull/5303
[2]: https://github.com/endlessm/flatpak/commit/13b59256

https://phabricator.endlessm.com/T34474