### PR TITLE
Remove eos-adblock-plus-extensions package

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,3 @@
-SUBDIRS = adblock-plus src chrome-helper data
+SUBDIRS = src chrome-helper data
 
 -include $(top_srcdir)/git.mk

--- a/adblock-plus/Makefile.am
+++ b/adblock-plus/Makefile.am
@@ -1,7 +1,0 @@
-chromeextdir = $(datadir)/google-chrome/extensions
-chromeext_DATA = cfhdojbkjhnklbpkdaibdccddilifddb.json
-
-chromiumextdir = $(datadir)/chromium/extensions
-chromiumext_DATA = cfhdojbkjhnklbpkdaibdccddilifddb.json
-
-EXTRA_DIST = cfhdojbkjhnklbpkdaibdccddilifddb.json

--- a/adblock-plus/cfhdojbkjhnklbpkdaibdccddilifddb.json
+++ b/adblock-plus/cfhdojbkjhnklbpkdaibdccddilifddb.json
@@ -1,3 +1,0 @@
-{
-  "external_update_url": "https://clients2.google.com/service/update2/crx"
-}

--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,6 @@ AC_SUBST(CHROME_HELPER_NAME, "eos-google-chrome-helper")
 
 AC_CONFIG_FILES([
 Makefile
-adblock-plus/Makefile
 data/Makefile
 chrome-helper/Makefile
 src/Makefile

--- a/debian/control
+++ b/debian/control
@@ -8,14 +8,6 @@ Build-Depends: debhelper (>= 9),
 Standards-Version: 3.8.0
 Homepage: http://www.endlessm.com
 
-Package: eos-adblock-plus-extensions
-Architecture: all
-Depends: ${misc:Depends}
-Description: Adblock Plus extension definitions
- This package provides the Adblock Plus extensions definitions, so that
- they are installed automatically and kept up to date when the user opens
- Chromium and Google Chrome.
-
 Package: eos-browser-tools
 Architecture: any
 Pre-Depends: dpkg (>= 1.15.6)

--- a/debian/eos-adblock-plus-extensions.install
+++ b/debian/eos-adblock-plus-extensions.install
@@ -1,2 +1,0 @@
-usr/share/chromium/extensions
-usr/share/google-chrome/extensions


### PR DESCRIPTION
We will no longer automatically install Adblock Plus by default due to
its increasingly-aggressive requests for donations. (In addition,
YouTube is now detecting ad blockers and refusing to play videos unless
you subscribe to the premium service.)

Remove the package and all files that went into it.

Depends on:

- [x] https://github.com/endlessm/eos-meta/pull/771

https://phabricator.endlessm.com/T34534
